### PR TITLE
COTD headlines with card search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/tracery"]
+	path = submodules/tracery
+	url = https://github.com/GoodGamery/tracery.git

--- a/config.js
+++ b/config.js
@@ -26,7 +26,6 @@ let config = {
 
 const submodules = {
   tracery: require('./submodules/tracery')
-  //tracery: require('./scratch/submodules/tracery/tracery.js')  
 };
 
 // apply overrides from config overrides file

--- a/config.js
+++ b/config.js
@@ -26,6 +26,7 @@ let config = {
 
 const submodules = {
   tracery: require('./submodules/tracery')
+  //tracery: require('./scratch/submodules/tracery/tracery.js')  
 };
 
 // apply overrides from config overrides file

--- a/src/data/grammar/card-types.yaml
+++ b/src/data/grammar/card-types.yaml
@@ -1,0 +1,9 @@
+---
+cardTypes:
+- artifact
+- creature
+- enchantment
+- land
+- instant
+- planeswalker
+- sorcery

--- a/src/data/grammar/creature-types.yaml
+++ b/src/data/grammar/creature-types.yaml
@@ -129,7 +129,7 @@
       "turtle",
       "unicorn",
       "vampire",
-      "veldalken",
+      "vedalken",
       "wall",
       "warrior",
       "weird",

--- a/src/data/grammar/creature-types.yaml
+++ b/src/data/grammar/creature-types.yaml
@@ -17,7 +17,6 @@
       "beast",
       "beeble",
       "bird",
-      "blinkmoth",
       "boar",
       "brushwagg",
       "camel",
@@ -25,7 +24,6 @@
       "centaur",
       "cephalid",
       "cleric",
-      "coward",
       "crab",
       "crocodile",
       "cyclops",
@@ -87,7 +85,6 @@
       "moonfolk",
       "monger",
       "monkey",
-      "moonfolk",
       "mutant",
       "nightmare",
       "ninja",
@@ -109,7 +106,6 @@
       "saproling",
       "satyr",
       "scarecrow",
-      "serf",
       "serpent",
       "shaman",
       "shapeshifter",
@@ -141,6 +137,12 @@
       "wurm",
       "yeti",
       "zombie"
+  ],
+  "nonCardCreatureTypes": [
+    "blinkmoth",
+    "citizen",
+    "coward",
+    "serf"
   ],
   "creatureTypesPlural": [
       "ants",

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -1,6 +1,8 @@
 ---
 cotdImage: |
-  [_cardname:#realCard#][_title:#cotdTitle#]#_title#: #_cardname# {htmlImg htmlImgString=`#_cotdHtml#` screenWidth=`1000` screenHeight=`500`}
+  [_cardname:#realCard#][_title:#cotdTitle#][_cotdImgUrl:https#colon#//goodgamery.com/api/mtg/image?card=#_cardname#]#_title#: #_cardname# {htmlImg htmlImgString=`#_cotdHtml#` screenWidth=`1000` screenHeight=`500`}
+  [_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_title:#cotdTitle#][_cardname:#_cardName1#][_cotdImgUrl:#_cardImgUrl1#][cotdDescription:#cotdCardTypeDescription#]#_title#: #_cardname# {htmlImg htmlImgString=`#_cotdHtml#` screenWidth=`1000` screenHeight=`500`}
+
 
 #This requires _cardname to be set already
 cotdImageCustom: |
@@ -8,6 +10,7 @@ cotdImageCustom: |
 cotdTitle:
   - CARD OF THE DAY
 cotdDescription:
+  - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #creatureTypes.capitalize# tribal pushes we made back in #randomCardSet.capitalize# and #randomCardSet.capitalize#."
   - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #creatureTypes.capitalize# tribal pushes we made back in #randomCardSet.capitalize# and #randomCardSet.capitalize#."
   - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, I don't think any keyword is off the menu moving forward."
   - "When your opponent plays #kindaGood.a# spell, your first #cardWhichDrawsCards# is probably to try to cause them to have #cardWhichCountersSpells.a#."
@@ -17,6 +20,59 @@ cotdDescription:
   - "Long ago, some #creatureTypes# decided to stick #massNoun#-infused #bodypart# armor onto what appears to be a pair of #itemNoun.s#. Today, almost every #characterClass# has donned a pair to dodge removal as they dash into battle."
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
   - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its back pocket!"
+
+cotdCardTypeDescriptionGood:
+ - "Only on #plane# would people see this #adjImpressive# #_creatureType# and nickname it [_nickname:The #adj.capitalizeAll.hyphenate# #characterClass.capitalizeAll#,#planeswalkerFirstName#'s #characterClass.capitalizeAll#]“#_nickname#”."
+ - "Now that we know that this #_creatureType# is the [_source:creator,progenitor,source]#_source# of all #_creatureType#kind across the multiverse (even #tribalCreature#), does that mean that every #_creatureType# is a Scion of the #_cardname#?"
+ - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be #adj#."
+ - "If you're looking for an impressive bomb in #teaserCardSet# limited, look no further than this #adj# #_creatureType#."
+ - "Things took a dark turn [_where:at the #storyLocation# #placeNoun#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
+ - "#_creatureType.capitalize# tribal, meet #format#. We've wanted to introduce you two for a while, and we thought [_adj:loving,friendly,abundant,populated,inhabited][_where:the #_creatureType#-#_adj# plane of #plane#,#teaserCardSet#]#_where# would be the perfect place for you to meet."
+
+cotdCardTypeNeedsWork:
+  - "Finally, #_creatureType# tribal has the [_key:lord,crucial piece]#_key# it needs to be [_adj:viable,constructed playable,competetive]#_adj#."
+
+cotdCardTypeDescription:
+ - "Only on #plane# would people see this #adjImpressive# #_creatureType# and nickname it [_nickname:The #adj.capitalizeAll.hyphenate# #characterClass.capitalizeAll#,#planeswalkerFirstName#'s #characterClass.capitalizeAll#]“#_nickname#”."
+ - "Now that we know that this #_creatureType# is the [_source:creator,progenitor,source]#_source# of all #_creatureType#kind across the multiverse (even #tribalCreature#), does that mean that every #_creatureType# is a Scion of the #_cardname#?"
+ - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be #adj#."
+ - "If you're looking for an impressive bomb in #teaserCardSet# limited, look no further than this #adj# #_creatureType#."
+ - "Things took a dark turn [_where:at the #storyLocation# #placeNoun#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
+ - "#_creatureType.capitalize# tribal, meet #format#. We've wanted to introduce you two for a while, and we thought [_adj:loving,friendly,abundant,populated,inhabited][_where:the #_creatureType#-#_adj# plane of #plane#,#teaserCardSet#]#_where# would be the perfect place for you to meet."
+
+adjImpressive:
+ - benevolent
+ - colossal
+ - deadly
+ - exotic
+ - extraordinary
+ - fearsome
+ - humble
+ - imposing
+ - magnificent
+ - majestic
+ - malevolent 
+ - modest
+ - noble
+ - peculiar
+ - sinister
+
+tribalCreature:
+ - "#adj.capitalizeAll# #_creatureType.capitalizeAll#"
+ - "#_creatureType.capitalizeAll# Champion"
+ - "#_creatureType.capitalizeAll# Egg"
+ - "#_creatureType.capitalizeAll# Exemplar" 
+ - "#_creatureType.capitalizeAll# Hatchling"
+ - "#_creatureType.capitalizeAll# Sovereign" 
+ - "#_creatureType.capitalizeAll# Tyrant"
+ - "#_creatureType.capitalizeAll# Ultimus"
+ - "#_creatureType.capitalizeAll# Warchief"
+ - "#_creatureType.capitalizeAll# Whelp"
+ - "#planeswalkerFirstName#'s #_creatureType.capitalizeAll#"
+ - "#_creatureType.capitalizeAll#lord #commonCharacterFirstName#"
+ - "#commonCharacterFirstName#, the #abstractNounMassNounOrEmotion.capitalize# #_creatureType.capitalizeAll#"
+ - "#commonCharacterFirstName#, #_creatureType.capitalizeAll# #characterClass.capitalize#"
+ - "#commonCharacterFirstName#, #characterClass.capitalizeAll# of the #placeNoun.capitalizeAll#"
 
 kindaGood:
   - good
@@ -174,7 +230,7 @@ _cotdHtml: |
     <div class="cotd">
       <div class="col col-40">
         <div style="margin-left: auto; margin-right: auto;">
-          <img class="mtg-card" src="https://goodgamery.com/api/mtg/image?card=#_cardname#" >
+          <img class="mtg-card" src="#_cotdImgUrl#">
         </div>
       </div>
       <div class="col col-60">

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -1,10 +1,21 @@
 ---
 cotdImage:
   - "[_cardname:#realCard#][_cotdDescription:#cotdDescription#][_cotdImgUrl:https#colon#//goodgamery.com/api/mtg/image?card=#_cardname#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
-
   - "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdCreatureTypeDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
-
   - "[_cardType:aura,equipment][#_cardType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdAuraOrEquipmentDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+  - "[#searchableCardCategory#][_cardText:#_cardCategorySearchTerm#][#_cardText.cardSearchByText#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdDescription:#cotdTextDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+
+searchableCardCategory:
+  - "[_cardCategory:removal spell][_toughness:1,2,3,4,5,X][_cardCategorySearchTerm:\"destroy target creature\",\"exile target creature\",\"enchanted creature can't attack or block\",\"fights target\",\"damage to target creature\",\"sacrifices a creature\",\"/-#_toughness# until\"]"
+  - "[_cardCategory:land destruction spell][_cardCategorySearchTerm:\"destroy target land\",\"sacrifices a land\"]"
+  - "[_cardCategory:pump spell,combat trick][_cardCategorySearchTerm:\"target creature gets +\",\"target creature gains\"]"
+  - "[_cardCategory:discard spell][_cardCategorySearchTerm:\"discards a card\",\"discards that card\"]"
+  - "[_cardCategory:counterspell][_cardCategorySearchTerm:\"counter target spell\"]"
+  - "[_cardCategory:direct damage spell,burn spell][_cardCategorySearchTerm:\"damage to target\"]"
+  - "[_cardCategory:ramp spell][_cardCategorySearchTerm:\"land card and put that card onto\",\"put them onto\",\"land card and put it onto\",\"#basicLands# card and put it onto\",\"#basicLands# card and put that card onto\"]"
+  - "[_cardCategory:lifegain spell][_amount:1,2,3,4,5,6,7,8,10,20,X][_cardCategorySearchTerm:\"gain life\",\"gain #_amount# life\"]"
+  - "[_cardCategory:cantrip][_cardCategorySearchTerm:\"draw a card.\"]"
+  - "[_cardCategory:slowtrip][_cardCategorySearchTerm:\"draw a card at the beginning\"]"
 
 #This requires _cardname to be set already
 cotdImageHtml: "{htmlImg htmlImgString=`#_cotdHtml#` screenWidth=`1000` screenHeight=`500`}"
@@ -14,20 +25,22 @@ cotdImageCustom: "#cotdImageHtml#"
 cotdTitle:
   - CARD OF THE DAY
 cotdDescription:
-  - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #creatureTypes.capitalize# tribal pushes we made back in #randomCardSet.capitalize# and #randomCardSet.capitalize#."
+  - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #creatureTypes.capitalize# tribal pushes [_futureSet:#teaserCardSet#,#novelCardSetName#][_madeOrAreMaking:we made back in #cardSet# and #cardSet#,we're making in #_futureSet#]#_madeOrAreMaking#."
   - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, I don't think any keyword is off the menu moving forward."
   - "When your opponent plays #kindaGood.a# spell, your first #cardWhichDrawsCards# is probably to try to cause them to have #cardWhichCountersSpells.a#."
   - "This versatile #cardCategory# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
-  - "This card seems #kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it becomes #reallyGood#."
-  - "It's no surprise that #basicColors.capitalize#'s most versatile removal spell finds its way into almost every #deckArchOrCategory# deck that can host it. Plus it offers some of the most hilarious flavor plays the game has ever seen."
+  - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it becomes [_reallyGood:#reallyGood#,really #_kindaGood#]#_reallyGood#."
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
-  - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its back pocket!"
+  - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its [_toolbox:back pocket,arsenal,toolbox,kit,playbook]#_toolbox#!"
 
 cotdCreatureTypeNeedsWork:
   - "Finally, #_creatureType# tribal has the [_key:lord,crucial piece]#_key# it needs to be [_adj:viable,constructed playable,competetive]#_adj#."
 
+cotdTextDescription:
+  - "It's no surprise that #_cardcolor.capitalize#'s [_superlative:#cardSuperlative#,second-#cardSuperlative#]#_superlative# #_cardCategory# finds its way into almost every [_decktype:#format#,#deckArchOrCategory#]#_decktype# deck that can host it. Plus it [_verbs:offers,enables,makes possible]#_verbs# some of the most #interestingPlay# the game has ever seen."
+
 cotdAuraOrEquipmentDescription:
-  - "Long ago, some #creatureTypes# decided to stick #massNoun#-infused #bodypart# armor onto what appears to be a pair of #itemNoun.s#. Today, almost every #characterClass# has donned a pair to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
+  - "Long ago, a #creatureTypes# decided to stick some #massNoun#-infused #bodypart# armor onto what appears to be a pair of #itemNoun.s#. Today, almost every #characterClass# has [_worn:donned,worn,sported,brandished]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
 
 cotdCreatureTypeDescription:
  - "Only on #plane# would people see this #adjImpressive# #_creatureType# and nickname it [_nickname:The #adj.capitalizeAll.hyphenate# #characterClass.capitalizeAll#,#planeswalkerFirstName#'s #characterClass.capitalizeAll#]“#_nickname#”."
@@ -36,6 +49,51 @@ cotdCreatureTypeDescription:
  - "If you're looking for an impressive bomb in #teaserCardSet# limited, look no further than this #adj# #_creatureType#."
  - "Things took a dark turn [_where:at the #storyLocation# #placeNoun#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
  - "#_creatureType.capitalize# tribal, meet #format#. We've wanted to introduce you two for a while, and we thought [_adj:loving,friendly,abundant,populated,inhabited][_where:the #_creatureType#-#_adj# plane of #plane#,#teaserCardSet#]#_where# would be the perfect place for you to meet."
+
+cardSuperlative:
+- most versatile
+- most flexible
+- most powerful
+- most underrated
+- most popular
+- most undercosted
+- most reprinted
+- most underestimated
+- most frequently sideboarded
+- most draftable
+- most iconic
+- least balanced
+- most conditional
+- most overrated
+- most overpriced
+- most underwhelming
+- most proxied
+- most counterfeited
+- least powerful
+- best-designed
+- narrowest
+- best
+- worst
+
+interestingPlayAdj:
+  - hilarious
+  - impressive
+  - memorable
+  - amazing
+  - over-the-top
+  - incredible
+  - ridiculous
+  - unbelievable
+
+interestingPlay:
+  - "#interestingPlayAdj# flavor plays"
+  - "#interestingPlayAdj# topdecks"
+  - "#interestingPlayAdj# bluffing opportunities"
+  - "#interestingPlayAdj# potential combos"
+  - "#interestingPlayAdj# windmill slams"
+  - "#interestingPlayAdj# blowouts"
+  - "#interestingPlayAdj# misplay opportunities"
+  - "#interestingPlayAdj# punts"
 
 adjImpressive:
  - benevolent
@@ -60,7 +118,7 @@ creatureActionVerb:
  - make a fool of themselves
  - take their chances
  - look their best
- - "#verbStrictlyIntransitive#"
+ - stay in character
 
 tribalCreature:
  - "#adj.capitalizeAll# #_creatureType.capitalizeAll#"
@@ -110,7 +168,7 @@ marginalThingToDo:
   - swap the order of layer 3 and 5
   - draw one card, then put it back
   - "reveal the [_where:top,bottom,first,last,middle]#_where# card #cardLocation#"
-  - continue drawing cards after losing the game
+  - "continue [_acting:drawing cards,gaining life,playing lands,talking,shuffling,blocking,searching their library]#_acting# after losing the game"
   - reduce the casting cost of red enchantments by 1 generic mana
   - delay combo kills by precisely 2 turns
   - "destroy #cardCategory.s# in #colors#"

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -1,14 +1,18 @@
 ---
 cotdImage:
   - "[_cardname:#realCard#][_cotdDescription:#cotdDescription#][_cotdImgUrl:https#colon#//goodgamery.com/api/mtg/image?card=#_cardname#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
-  - "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cotdImgUrl:#_cardImgUrl1#][_cotdDescription:#cotdCreatureTypeDescription#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+  - "[#cotdCreatureTypeSearch#][_cotdDescription:#cotdCreatureTypeDescription#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
   - "[_cardType:aura,equipment][#_cardType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdAuraOrEquipmentDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
-  - "[#searchableCardCategory#][_cardText:#_cardCategorySearchTerm#][#_cardText.cardSearchByText#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdDescription:#cotdTextDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+  - "[#searchableCardCategory#][#cotdCardCategorySearch#][_cotdDescription:#cotdTextDescription#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+
+cotdCreatureTypeSearch: "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdImgUrl:#_cardImgUrl1#]"
+cotdCardCategorySearch: "[_cardText:#_cardCategorySearchTerm#][#_cardText.cardSearchByText#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdImgUrl:#_cardImgUrl1#]"
 
 searchableCardCategory:
   - "[_cardCategory:removal spell][_toughness:1,2,3,4,5,X][_cardCategorySearchTerm:\"destroy target creature\",\"exile target creature\",\"enchanted creature can't attack\",\"fights target\",\"damage to target creature\",\"sacrifices a creature\",\"/-#_toughness# until\",\"enchanted creature doesn't\"]"
   - "[_cardCategory:land destruction spell][_cardCategorySearchTerm:\"destroy target land\",\"sacrifices a land\"]"
-  - "[_cardCategory:pump spell,combat trick][_cardCategorySearchTerm:\"target creature gets +\",\"target creature gains\"]"
+  - "[_cardCategory:pump spell][_cardCategorySearchTerm:\"target creature gets +\",\"creatures you control get +\"]"
+  - "[_cardCategory:combat trick][_cardCategorySearchTerm:\"target creature gets +\",\"target creature gains\"]"
   - "[_cardCategory:discard spell][_cardCategorySearchTerm:\"discards a card\",\"discards that card\"]"
   - "[_cardCategory:counterspell][_cardCategorySearchTerm:\"counter target\"]"
   - "[_cardCategory:direct damage spell,burn spell][_cardCategorySearchTerm:\"damage to target\"]"
@@ -26,9 +30,9 @@ cotdImageCustom: "#cotdImageHtml#"
 cotdTitle:
   - CARD OF THE DAY
 cotdDescription:
-  - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, I don't think any keyword is off the menu moving forward."
+  - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, we can't really promise that any keyword is off the menu moving forward."
   - "When your opponent plays #kindaGood.a# spell, your first #cardWhichDrawsCards# is probably to try to cause them to have #cardWhichCountersSpells.a#."
-  - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it becomes [_reallyGood:#reallyGood#,really #_kindaGood#]#_reallyGood#."
+  - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it [_result:becomes #reallyGood#,seems really #_kindaGood#]#_result#."
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
   - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its [_toolbox:back pocket,arsenal,toolbox,kit,playbook]#_toolbox#!"
 
@@ -37,7 +41,7 @@ cotdCreatureTypeNeedsWork:
 
 cotdTextDescription:
   - "It's no surprise that #_cardcolor.capitalize#'s [_superlative:#cardSuperlative#,second-#cardSuperlative#]#_superlative# #_cardCategory# finds its way into almost every [_decktype:#format#,#deckArchOrCategory#]#_decktype# deck that can host it. Plus it [_verbs:offers,enables,makes possible]#_verbs# some of the most #interestingPlay# the game has ever seen."
-  - "[_cardCategory:#_cardCategory#,]This versatile #_cardCategory# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
+  - "[_search:[#cotdCreatureTypeSearch#][_cardDesc:#_creatureType#],[#cotdCardCategorySearch#][_cardDesc:#_cardCategory#]][#_search#]This versatile #_cardDesc# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
 
 cotdAuraOrEquipmentDescription:
   - "Long ago, [_adj:inventive,resourceful,desparate,clever,crafty,beleagured]#_adj.a# #creatureTypes# decided to stick some #massNoun#-infused [_equipmentPart:#bodypart# armor,blades,spikes]#_equipmentPart# onto what appears to be a [_surface:#itemNoun#,pair of #itemNoun.s#]#_surface#. Today, almost every #characterClass# [_worn:has donned,has worn,wields,sports]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
@@ -119,7 +123,7 @@ creatureActionVerb:
  - make a fool of themselves
  - look respectable
  - stay in character
- - "really go [_crazy:wild,crazy,nuts]#_crazy"
+ - "really go [_crazy:wild,crazy,nuts]#_crazy#"
 
 tribalCreature:
  - "#adj.capitalizeAll# #_creatureType.capitalizeAll#"

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -1,21 +1,22 @@
 ---
 cotdImage:
   - "[_cardname:#realCard#][_cotdDescription:#cotdDescription#][_cotdImgUrl:https#colon#//goodgamery.com/api/mtg/image?card=#_cardname#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
-  - "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdCreatureTypeDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
+  - "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cotdImgUrl:#_cardImgUrl1#][_cotdDescription:#cotdCreatureTypeDescription#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
   - "[_cardType:aura,equipment][#_cardType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdAuraOrEquipmentDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
   - "[#searchableCardCategory#][_cardText:#_cardCategorySearchTerm#][#_cardText.cardSearchByText#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdDescription:#cotdTextDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
 
 searchableCardCategory:
-  - "[_cardCategory:removal spell][_toughness:1,2,3,4,5,X][_cardCategorySearchTerm:\"destroy target creature\",\"exile target creature\",\"enchanted creature can't attack or block\",\"fights target\",\"damage to target creature\",\"sacrifices a creature\",\"/-#_toughness# until\"]"
+  - "[_cardCategory:removal spell][_toughness:1,2,3,4,5,X][_cardCategorySearchTerm:\"destroy target creature\",\"exile target creature\",\"enchanted creature can't attack\",\"fights target\",\"damage to target creature\",\"sacrifices a creature\",\"/-#_toughness# until\",\"enchanted creature doesn't\"]"
   - "[_cardCategory:land destruction spell][_cardCategorySearchTerm:\"destroy target land\",\"sacrifices a land\"]"
   - "[_cardCategory:pump spell,combat trick][_cardCategorySearchTerm:\"target creature gets +\",\"target creature gains\"]"
   - "[_cardCategory:discard spell][_cardCategorySearchTerm:\"discards a card\",\"discards that card\"]"
-  - "[_cardCategory:counterspell][_cardCategorySearchTerm:\"counter target spell\"]"
+  - "[_cardCategory:counterspell][_cardCategorySearchTerm:\"counter target\"]"
   - "[_cardCategory:direct damage spell,burn spell][_cardCategorySearchTerm:\"damage to target\"]"
   - "[_cardCategory:ramp spell][_cardCategorySearchTerm:\"land card and put that card onto\",\"put them onto\",\"land card and put it onto\",\"#basicLands# card and put it onto\",\"#basicLands# card and put that card onto\"]"
   - "[_cardCategory:lifegain spell][_amount:1,2,3,4,5,6,7,8,10,20,X][_cardCategorySearchTerm:\"gain life\",\"gain #_amount# life\"]"
   - "[_cardCategory:cantrip][_cardCategorySearchTerm:\"draw a card.\"]"
   - "[_cardCategory:slowtrip][_cardCategorySearchTerm:\"draw a card at the beginning\"]"
+  - "[_cardCategory:bounce spell][_targetCardType:creature,permanent,nonland permanent][_cardCategorySearchTerm:\"return target #_targetCardType# to\"]"
 
 #This requires _cardname to be set already
 cotdImageHtml: "{htmlImg htmlImgString=`#_cotdHtml#` screenWidth=`1000` screenHeight=`500`}"
@@ -25,10 +26,8 @@ cotdImageCustom: "#cotdImageHtml#"
 cotdTitle:
   - CARD OF THE DAY
 cotdDescription:
-  - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #creatureTypes.capitalize# tribal pushes [_futureSet:#teaserCardSet#,#novelCardSetName#][_madeOrAreMaking:we made back in #cardSet# and #cardSet#,we're making in #_futureSet#]#_madeOrAreMaking#."
   - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, I don't think any keyword is off the menu moving forward."
   - "When your opponent plays #kindaGood.a# spell, your first #cardWhichDrawsCards# is probably to try to cause them to have #cardWhichCountersSpells.a#."
-  - "This versatile #cardCategory# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
   - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it becomes [_reallyGood:#reallyGood#,really #_kindaGood#]#_reallyGood#."
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
   - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its [_toolbox:back pocket,arsenal,toolbox,kit,playbook]#_toolbox#!"
@@ -38,17 +37,19 @@ cotdCreatureTypeNeedsWork:
 
 cotdTextDescription:
   - "It's no surprise that #_cardcolor.capitalize#'s [_superlative:#cardSuperlative#,second-#cardSuperlative#]#_superlative# #_cardCategory# finds its way into almost every [_decktype:#format#,#deckArchOrCategory#]#_decktype# deck that can host it. Plus it [_verbs:offers,enables,makes possible]#_verbs# some of the most #interestingPlay# the game has ever seen."
+  - "[_cardCategory:#_cardCategory#,]This versatile #_cardCategory# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
 
 cotdAuraOrEquipmentDescription:
-  - "Long ago, a #creatureTypes# decided to stick some #massNoun#-infused #bodypart# armor onto what appears to be a pair of #itemNoun.s#. Today, almost every #characterClass# has [_worn:donned,worn,sported,brandished]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
+  - "Long ago, [_adj:inventive,resourceful,desparate,clever,crafty,beleagured]#_adj.a# #creatureTypes# decided to stick some #massNoun#-infused [_equipmentPart:#bodypart# armor,blades,spikes]#_equipmentPart# onto what appears to be a [_surface:#itemNoun#,pair of #itemNoun.s#]#_surface#. Today, almost every #characterClass# [_worn:has donned,has worn,wields,sports]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
 
 cotdCreatureTypeDescription:
  - "Only on #plane# would people see this #adjImpressive# #_creatureType# and nickname it [_nickname:The #adj.capitalizeAll.hyphenate# #characterClass.capitalizeAll#,#planeswalkerFirstName#'s #characterClass.capitalizeAll#]“#_nickname#”."
  - "Now that we know that this #_creatureType# is the [_source:creator,progenitor,source]#_source# of all #_creatureType#kind across the multiverse (even #tribalCreature#), does that mean that every #_creatureType# is a [_minionTitle:Scion of the #_cardname#,Spawn of #_cardname#,Minion of #_cardname#, #_cardname.hyphenate#'s Faithful']#_minionTitle#?"
- - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be #adj#."
+ - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be[_adv:, really, pretty, extremely, surprisingly] #adj#."
  - "If you're looking for an impressive bomb in #teaserCardSet# limited, look no further than this #adj# #_creatureType#."
  - "Things took a dark turn [_where:at the #storyLocation# #placeNoun#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
  - "#_creatureType.capitalize# tribal, meet #format#. We've wanted to introduce you two for a while, and we thought [_adj:loving,friendly,abundant,populated,inhabited][_where:the #_creatureType#-#_adj# plane of #plane#,#teaserCardSet#]#_where# would be the perfect place for you to meet."
+ - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #_creatureType.capitalizeAll# tribal pushes [_futureSet:#teaserCardSet#,#novelCardSetName#][_madeOrAreMaking:we made back in #cardSet# and #cardSet#,we're making in #_futureSet#]#_madeOrAreMaking#."
 
 cardSuperlative:
 - most versatile
@@ -114,11 +115,11 @@ adjImpressive:
 
 creatureActionVerb:
  - dodge removal
- - "[_what:inspire,rally,encourage,mobilize,impress]#_what# their [_who:comrades,their fellow #creatureType.s#]#_who#"
+ - "[_what:inspire,rally,encourage,mobilize,impress]#_what# their comrades"
  - make a fool of themselves
- - take their chances
- - look their best
+ - look respectable
  - stay in character
+ - "really go [_crazy:wild,crazy,nuts]#_crazy"
 
 tribalCreature:
  - "#adj.capitalizeAll# #_creatureType.capitalizeAll#"

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -43,9 +43,6 @@ cotdDescription:
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
   - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its [_toolbox:back pocket,arsenal,toolbox,kit,playbook]#_toolbox#!"
 
-cotdCreatureTypeNeedsWork:
-  - "Finally, #_creatureType# tribal has the [_key:lord,crucial piece]#_key# it needs to be [_adj:viable,constructed playable,competetive]#_adj#."
-
 cotdTextDescription:
   - "It's no surprise that #_cardcolor.capitalize#'s [_superlative:#cardSuperlative#,second-#cardSuperlative#]#_superlative# #_cardCategory# finds its way into almost every [_decktype:#format#,#deckArchOrCategory#]#_decktype# deck that can host it. Plus it [_verbs:offers,enables,makes possible]#_verbs# some of the most #interestingPlay# the game has ever seen."
   - "[#cotdParameterizedCardSearch#]This versatile #_cardDesc# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"

--- a/src/data/grammar/mtg-card-of-the-day.yaml
+++ b/src/data/grammar/mtg-card-of-the-day.yaml
@@ -5,8 +5,14 @@ cotdImage:
   - "[_cardType:aura,equipment][#_cardType.cardSearchByType#][_cardname:#_cardName1#][_cotdDescription:#cotdAuraOrEquipmentDescription#][_cotdImgUrl:#_cardImgUrl1#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
   - "[#searchableCardCategory#][#cotdCardCategorySearch#][_cotdDescription:#cotdTextDescription#][_title:#cotdTitle#]#_title#: #_cardname##cotdImageHtml#"
 
+cotdCardTypeSearch: "[_cardType:#cardTypes#][#_cardType.cardSearchByType#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdImgUrl:#_cardImgUrl1#]"
 cotdCreatureTypeSearch: "[_creatureType:#creatureTypes#][#_creatureType.cardSearchByType#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdImgUrl:#_cardImgUrl1#]"
 cotdCardCategorySearch: "[_cardText:#_cardCategorySearchTerm#][#_cardText.cardSearchByText#][_cardname:#_cardName1#][_cardcolor:#_cardColor1#][_cotdImgUrl:#_cardImgUrl1#]"
+
+cotdParameterizedCardSearch:
+  - "[#cotdCardTypeSearch#][_cardDesc:#_cardType#]"
+  - "[#cotdCreatureTypeSearch#][_cardDesc:#_creatureType#]"
+  - "[#cotdCardCategorySearch#][_cardDesc:#_cardCategory#]"
 
 searchableCardCategory:
   - "[_cardCategory:removal spell][_toughness:1,2,3,4,5,X][_cardCategorySearchTerm:\"destroy target creature\",\"exile target creature\",\"enchanted creature can't attack\",\"fights target\",\"damage to target creature\",\"sacrifices a creature\",\"/-#_toughness# until\",\"enchanted creature doesn't\"]"
@@ -16,7 +22,7 @@ searchableCardCategory:
   - "[_cardCategory:discard spell][_cardCategorySearchTerm:\"discards a card\",\"discards that card\"]"
   - "[_cardCategory:counterspell][_cardCategorySearchTerm:\"counter target\"]"
   - "[_cardCategory:direct damage spell,burn spell][_cardCategorySearchTerm:\"damage to target\"]"
-  - "[_cardCategory:ramp spell][_cardCategorySearchTerm:\"land card and put that card onto\",\"put them onto\",\"land card and put it onto\",\"#basicLands# card and put it onto\",\"#basicLands# card and put that card onto\"]"
+  - "[_cardCategory:ramp spell][_cardCategorySearchTerm:\"land card and put that card onto\",\"put them onto\",\"land card and put it onto\",\"forest card and put it onto\",\"forest card and put that card onto\"]"
   - "[_cardCategory:lifegain spell][_amount:1,2,3,4,5,6,7,8,10,20,X][_cardCategorySearchTerm:\"gain life\",\"gain #_amount# life\"]"
   - "[_cardCategory:cantrip][_cardCategorySearchTerm:\"draw a card.\"]"
   - "[_cardCategory:slowtrip][_cardCategorySearchTerm:\"draw a card at the beginning\"]"
@@ -29,10 +35,11 @@ cotdImageCustom: "#cotdImageHtml#"
 
 cotdTitle:
   - CARD OF THE DAY
+
 cotdDescription:
-  - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, we can't really promise that any keyword is off the menu moving forward."
+  - "This blast from the [_time:future,past,future,past,present,distant future,distant past]#_time# is back, and it's still the only way for a player to #marginalThingToDo#! Although with #keyword# coming back, we can't promise that any keyword is really off the menu moving forward."
   - "When your opponent plays #kindaGood.a# spell, your first #cardWhichDrawsCards# is probably to try to cause them to have #cardWhichCountersSpells.a#."
-  - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that it means there's a legendary #creatureTypes.capitalize# token to be had. Then it [_result:becomes #reallyGood#,seems really #_kindaGood#]#_result#."
+  - "This card seems [_kindaGood:#kindaGood#]#_kindaGood#...until you realize that #surprisingResult#. Then it [_result:becomes #reallyGood#,seems really #_kindaGood#]#_result#."
   - "Every player aspires to have as many #_cardname.s# as they have #colors# #deckArchOrCategory# decks."
   - "#multicolor# #deckLimitedArchetype.capitalize# may be the favored deck for this color combo, but that doesn't mean #multicolor# #keyword# isn't always happy to have another tool in its [_toolbox:back pocket,arsenal,toolbox,kit,playbook]#_toolbox#!"
 
@@ -41,19 +48,19 @@ cotdCreatureTypeNeedsWork:
 
 cotdTextDescription:
   - "It's no surprise that #_cardcolor.capitalize#'s [_superlative:#cardSuperlative#,second-#cardSuperlative#]#_superlative# #_cardCategory# finds its way into almost every [_decktype:#format#,#deckArchOrCategory#]#_decktype# deck that can host it. Plus it [_verbs:offers,enables,makes possible]#_verbs# some of the most #interestingPlay# the game has ever seen."
-  - "[_search:[#cotdCreatureTypeSearch#][_cardDesc:#_creatureType#],[#cotdCardCategorySearch#][_cardDesc:#_cardCategory#]][#_search#]This versatile #_cardDesc# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
+  - "[#cotdParameterizedCardSearch#]This versatile #_cardDesc# has already shown itself as an all-star of the new metagame. Check out the Pro Tour this weekend to see if the #deckArchOrCategory# dominance continues!"
 
 cotdAuraOrEquipmentDescription:
-  - "Long ago, [_adj:inventive,resourceful,desparate,clever,crafty,beleagured]#_adj.a# #creatureTypes# decided to stick some #massNoun#-infused [_equipmentPart:#bodypart# armor,blades,spikes]#_equipmentPart# onto what appears to be a [_surface:#itemNoun#,pair of #itemNoun.s#]#_surface#. Today, almost every #characterClass# [_worn:has donned,has worn,wields,sports]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
+  - "Long ago, [_adj:inventive,resourceful,desparate,clever,crafty,beleagured]#_adj.a# #creatureTypes# decided to stick some #massNoun.hyphenate#-infused [_equipmentPart:#bodypart# armor,blades,spikes,bracers,pauldrons,gauntlets,rivets,ribbons,pinstripes,toothpicks,pipe cleaners,pom poms,rhinestones]#_equipmentPart# onto what appears to be a [_surface:#itemNoun#,pair of #itemNoun.s#]#_surface#. Today, almost every #characterClass# [_worn:has donned,has worn,wields,sports]#_worn# [_theArmor:one of these,a pair]#_theArmor# to #creatureActionVerb# as they [_verb:dash,rumble,rush,roll]#_verb# into battle."
 
 cotdCreatureTypeDescription:
  - "Only on #plane# would people see this #adjImpressive# #_creatureType# and nickname it [_nickname:The #adj.capitalizeAll.hyphenate# #characterClass.capitalizeAll#,#planeswalkerFirstName#'s #characterClass.capitalizeAll#]“#_nickname#”."
- - "Now that we know that this #_creatureType# is the [_source:creator,progenitor,source]#_source# of all #_creatureType#kind across the multiverse (even #tribalCreature#), does that mean that every #_creatureType# is a [_minionTitle:Scion of the #_cardname#,Spawn of #_cardname#,Minion of #_cardname#, #_cardname.hyphenate#'s Faithful']#_minionTitle#?"
- - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be[_adv:, really, pretty, extremely, surprisingly] #adj#."
+ - "Now that we know that this #_creatureType# is the [_source:creator,progenitor,source]#_source# of all #_creatureType#kind across the multiverse (even #tribalCreature#), does that mean that every #_creatureType# is a [_minionTitle:Scion of the #_cardname#,Spawn of #_cardname#,Minion of #_cardname#, #_cardname.hyphenate#'s Faithful]#_minionTitle#?"
+ - "#_creatureType.capitalize.s# may not ascend to #characterClass.hyphenate#hood very often, but when they do, the results tend to be[_adv:, really, pretty, extremely, surprisingly, quite, truly] #adj#."
  - "If you're looking for an impressive bomb in #teaserCardSet# limited, look no further than this #adj# #_creatureType#."
- - "Things took a dark turn [_where:at the #storyLocation# #placeNoun#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
+ - "Things took a dark turn [_where:at the #storyLocation# #placeNoun.capitalize#,in #minorStoryLocation#,in #nonPlaneLocation#]#_where# after this #_creatureType# learned they had run out of [_item:#itemNoun.s#,#massNoun#]#_item#."
  - "#_creatureType.capitalize# tribal, meet #format#. We've wanted to introduce you two for a while, and we thought [_adj:loving,friendly,abundant,populated,inhabited][_where:the #_creatureType#-#_adj# plane of #plane#,#teaserCardSet#]#_where# would be the perfect place for you to meet."
- - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #_creatureType.capitalizeAll# tribal pushes [_futureSet:#teaserCardSet#,#novelCardSetName#][_madeOrAreMaking:we made back in #cardSet# and #cardSet#,we're making in #_futureSet#]#_madeOrAreMaking#."
+ - "If you're looking to beef up #character#'s tribal support next [_date:business day,weekend,week,month,week,month,year,year,decade,century]#_date#, make sure to look at the #_creatureType.capitalizeAll# tribal pushes [_futureSet:#teaserCardSet#,#novelCardSetName#][_madeOrAreMaking:we made back in #cardSet# and #cardSet#,we're making in #_futureSet.capitalizeAll#]#_madeOrAreMaking#."
 
 cardSuperlative:
 - most versatile
@@ -145,13 +152,14 @@ tribalCreature:
 kindaGood:
   - good
   - great
-  - ok
+  - okay
   - spicy
   - ridiculous
   - terrible
   - mildly interesting
   - bewildering
   - unimpressive
+  - reasonable
 
 reallyGood:
   - wonderful
@@ -170,13 +178,23 @@ marginalThingToDo:
   - combine two cards together in one sleeve
   - rotate cards through space and time to reveal their secret third side
   - conditionally gain one life
-  - swap the order of layer 3 and 5
+  - swap the order of layers 3 and 5
   - draw one card, then put it back
   - "reveal the [_where:top,bottom,first,last,middle]#_where# card #cardLocation#"
   - "continue [_acting:drawing cards,gaining life,playing lands,talking,shuffling,blocking,searching their library]#_acting# after losing the game"
   - reduce the casting cost of red enchantments by 1 generic mana
-  - delay combo kills by precisely 2 turns
+  - delay combo kills by precisely #count# turns
   - "destroy #cardCategory.s# in #colors#"
+  - peek at the top card of your library
+
+surprisingResult:
+  - "it means there's a legendary #creatureTypes.capitalize# token to be had"
+  - "it allows you to play #cardCategory.a# for free"
+  - "it's the only card in Magic that lets you #marginalThingToDo#"
+  - "it can let you take up to #count# extra turns"
+  - "you get to return it to your hand"
+  - "you can combo it with #cardAlone#."
+  - "it's going to be #rarity.a# in #teaserCardSet.capitalizeAll#"
 
 cardWhichDrawsCards:
   - Impulse

--- a/src/data/grammar/mtg-characters.yaml
+++ b/src/data/grammar/mtg-characters.yaml
@@ -147,7 +147,7 @@
     "priest", "ancestor", "martyr", "monarch", "voyager", "general", "victim", "customer", "seeker", "automaton", "keeper", "genius",
     "gymnast", "demagogue", "malcontent", "maniac", "bookworm", "egghead", "ringleader", "ringmaster",  "gatekeeper", "keymaster",
     "survivor", "vegan", "renegade", "flunky", "henchman", "emissary", "orphan", "enemy", "commander", "vagrant", "vagabond", "puppet",
-    "dog catcher"
+    "dog catcher", "coward", "citizen", "heretic", "fugitive", "outlaw"
  	],
   "characterTitle": [
   	"#characterClass#",

--- a/src/data/grammar/mtg-formats.yaml
+++ b/src/data/grammar/mtg-formats.yaml
@@ -14,7 +14,7 @@
       "Two-Headed Giant",
       "Kitchen Table Magic",
       "#alternativeConstructedFormat#",
-      "#alternativeDraftFormat# draft"
+      "#alternativeDraftFormat#"
   ],
   "normalFormat": [
       "Standard",
@@ -37,11 +37,12 @@
   ],
   "alternativeDraftFormat": [
     "Backdraft",
-    "Mini-master",
-    "Rotisserie",
-    "Rochester",
-    "Solomon",
-    "Winston"
+    "Flip It or Rip It",
+    "Mini-Master",
+    "Rotisserie Draft",
+    "Rochester Draft",
+    "Solomon Draft",
+    "Winston Draft"
   ],
   "expansionBlock": [
     "Ice Age",

--- a/src/data/grammar/mtg-sets.yaml
+++ b/src/data/grammar/mtg-sets.yaml
@@ -5,6 +5,8 @@
       "Archenemy",
       "Avacyn Restored",
       "Chronicles",
+      "Conspiracy",
+      "Conspiracy#colon# Take the Crown",
       "Eldritch Moon",
       "Fallen Empires",
       "Fifth Edition",
@@ -14,12 +16,14 @@
       "Invasion",
       "Legends",
       "Mercadian Masques",
+      "Mirage",
       "Planechase",
       "Portal Three Kingdoms",
       "Ravnica",
       "Revised",
       "Shards of Alara",
       "Shadowmoor",
+      "Tempest",
       "Time Spiral",
       "Unglued",
       "Unhinged",
@@ -158,10 +162,10 @@
   "collectiveActionOrRealm": [
     "rise", "revenge", "clash", "realm", "call", "sphere", "tales", "flight", "festival", "cult", "order", "ruin", "empire", "conclave",
     "council", "mutiny", "decline", "fall", "fate", "scourge", "legacy", "whispers", "way", "triumph", "season", "secrets", "retribution",
-    "reign", "rebellion", "oath", "might", "kiss", "dance", "howl", "moan", "feast", "hunger", "footsteps"
+    "reign", "rebellion", "oath", "might", "kiss", "dance", "howl", "moan", "feast", "hunger", "footsteps", "clan"
   ],
   "collective": [
-    "league", "guild", "tournament", "city",  "kingdom", "fellowship", "clan", "ruin"
+    "league", "guild", "tournament", "city",  "kingdom", "fellowship", "ruin"
   ],
   "cardSetSuffix": ["reborn", "revisited", "unleashed", "dawn", "ascendant"]
 }

--- a/src/data/grammar/nouns.yaml
+++ b/src/data/grammar/nouns.yaml
@@ -55,7 +55,7 @@
       "doodad", "bone", "vuvuzela", "handlebar moustache", "horseshoe", "sweater vest", "prawn", "#gameAccessory#", "veil", "shrubbery",
       "apron", "bow tie", "glove", "fanny pack", "loincloth", "#bodypart#", "saxophone", "birdcage", "balloon", "weathervane", "backpack",
       "cactus", "spellbomb", "chair", "stepladder", "gravy boat", "memorial", "statue", "game", "relic", "ring", "appendage", "#bodypart#",
-      "clog", "shoe", "rubber ducky", "rubber chicken"
+      "clog", "shoe", "rubber ducky", "rubber chicken", "egg", "trinket"
   ],
   "placeNoun": [
       "temple", "palace", "castle", "garden", "market", "dungeon", "sanctuary", "mansion", "kingdom", "colony", "vacation rental", "graveyard",
@@ -66,7 +66,7 @@
       "portal", "hair salon", "shipwreck", "pasture", "circus tent", "fortress", "junkyard", "pillow fort", "mausoleum", "sepulcher",
       "kitchenette", "churchyard", "mortuary", "abattoir", "art studio", "pet store", "armory", "gazebo", "playground", "animal shelter",
       "gazebo", "taco stand", "pyramid", "igloo", "dude ranch", "cabin", "gas station", "tattoo parlor", "tavern", "vineyard", "drawbridge",
-      "pantry", "stairwell", "petting zoo", "supermarket", "bayou", "ziggurat", "clocktower", "lair", "void", "quarry"
+      "pantry", "stairwell", "petting zoo", "supermarket", "bayou", "ziggurat", "clocktower", "lair", "void", "quarry", "farmer's market"
   ],
   "irregularPluralNoun": [
       "teeth", "feet", "pants", "geese", "fish", "children", "stimuli", "potatoes", "knives", "ashes", "riches", "hypotheses", "neuroses",

--- a/src/lib/plugins/tracery/custom-modifiers.js
+++ b/src/lib/plugins/tracery/custom-modifiers.js
@@ -17,18 +17,58 @@ function hyphenate(s) {
   return s.replace(/\s+/g, '-');
 }
 
-async function cardSearchByType(s) {
-  
-  const SEARCH_API_JSON_URL = 'https://goodgamery.com/api/mtg/card/json';
-  
+async function cardSearchBySet(s) {
+  const query = { 
+    q: 'set:' + s,
+    limit: 1,
+    sort: 'random'
+  };
+  return cardFinderSearch(query);    
+}
+
+async function cardSearchByText(s) {
+  const query = { 
+    q: 'text:' + s,
+    limit: 1,
+    sort: 'random'
+  };
+  return cardFinderSearch(query);  
+}
+
+async function cardSearchByType(s) {  
   const query = { 
     q: 't:' + s,
     limit: 1,
     sort: 'random'
   };
+  return cardFinderSearch(query);
+}
 
-  console.log('[cardSearchByType] searching for card with type ' + s);
+function getColorDescription(colorIdentity) {
+  const colorNames = {
+    W: 'white',
+    U: 'blue',
+    B: 'black',
+    R: 'red',
+    G: 'green',
+    WU: 'UW',
+    WR: 'RW',
+    WG: 'GW',
+    BR: 'RB',
+    UBG: 'BUG',
+    URG: 'RUG'
+  };
 
+  if (!colorIdentity) {
+    return 'colorless';
+  }
+
+  const colorDescription = colorIdentity.join('');
+  return colorNames[colorDescription] || colorDescription;
+}
+
+async function cardFinderSearch(query) {
+  const SEARCH_API_JSON_URL = 'https://goodgamery.com/api/mtg/card/json';
   return new Promise(resolve => {
     request.get({ url: SEARCH_API_JSON_URL, qs: query }, (err, data, body) => {
       if (err) {
@@ -37,21 +77,23 @@ async function cardSearchByType(s) {
       }
 
       try {
-        // console.log('[cardSearchByType] response:\n' + JSON.stringify(data));
-        // console.log('[cardSearchByType] body:\n' + JSON.stringify(body));
+        console.log('[cardFinderSearch] reqdata:\n' + JSON.stringify(data));
+        // console.log('[cardFinderSearch] result:\n' + JSON.stringify(JSON.parse(body)[0], null, '\t'));
         const result = JSON.parse(body);
         const name = result[0].name;
         const imgUrl = result[0].imageUrl.replace(/:/g,'#colon#');
+        const color = getColorDescription(result[0].colorIdentity);
 
         console.log('name: ' + name);
         console.log('imageUrl: ' + imgUrl);
-        resolve(`[_cardName1:${name}][_cardImgUrl1:${imgUrl}]`);
+        console.log('color: ' + color);
+        resolve(`[_cardName1:${name}][_cardImgUrl1:${imgUrl}][_cardColor1:${color}]`);
       } catch (e) {
         console.warn('Error parsing card data: ' + e);
         resolve('NO RESULTS');
       }
     });
-  });
+  });  
 }
 
 module.exports = { 
@@ -59,5 +101,7 @@ module.exports = {
   hyphenate: hyphenate,
   noPunctuation: noPunctuation,
   noSpaces: noSpaces,
-  cardSearchByType: cardSearchByType
+  cardSearchBySet: cardSearchBySet,  
+  cardSearchByText: cardSearchByText,
+  cardSearchByType: cardSearchByType  
 };

--- a/src/lib/plugins/tracery/custom-modifiers.js
+++ b/src/lib/plugins/tracery/custom-modifiers.js
@@ -1,4 +1,5 @@
 'use strict';
+const request = require('request');
 
 function allCaps(s) {
   return s.toUpperCase();
@@ -12,19 +13,49 @@ function noSpaces(s) {
   return s.replace(/\s+/g, '');
 }
 
-// TODO: replace this with a good example
-async function allCapsAsyncTest(s) {
+function hyphenate(s) {
+  return s.replace(/\s+/g, '-');
+}
+
+async function cardSearchByType(s) {
+  
+  const SEARCH_API_JSON_URL = 'https://goodgamery.com/api/mtg/card/json';
+  
+  const query = { 
+    q: 't:' + s,
+    limit: 1,
+    sort: 'random'
+  };
+
   return new Promise(resolve => {
-    console.log('waiting 1000ms...');
-    setTimeout(() => {
-      resolve(s.toUpperCase());
-    }, 1000);
+    request.get({ url: SEARCH_API_JSON_URL, qs: query }, (err, data, body) => {
+      if (err) {
+        console.warn('Error fetching card data: ' + err);        
+        resolve('NO RESULTS');
+      }
+
+      try {
+        console.log('[cardSearchByType] response:\n' + JSON.stringify(data));
+        console.log('[cardSearchByType] body:\n' + JSON.stringify(body));
+        const result = JSON.parse(body);
+        const name = result[0].name;
+        const imgUrl = result[0].imageUrl.replace(/:/g,'#colon#');
+
+        console.log('name: ' + name);
+        console.log('imageUrl: ' + imgUrl);
+        resolve(`[_cardName1:${name}][_cardImgUrl1:${imgUrl}]`);
+      } catch (e) {
+        console.warn('Error parsing card data: ' + e);
+        resolve('NO RESULTS');
+      }
+    });
   });
 }
 
 module.exports = { 
   allCaps: allCaps,
+  hyphenate: hyphenate,
   noPunctuation: noPunctuation,
   noSpaces: noSpaces,
-  allCapsAsyncTest: allCapsAsyncTest
+  cardSearchByType: cardSearchByType
 };

--- a/src/lib/render-image.js
+++ b/src/lib/render-image.js
@@ -4,6 +4,7 @@ const webshot = require('webshot');
 const svg2png = require('svg2png');
 const Jimp = require('jimp');
 const fs =  require('fs');
+const config = global.mtgnewsbot.config;
 
 const webshotOptions = {
   windowSize: { width: 1024, height: 768 }
@@ -22,7 +23,9 @@ function renderImageFromHeadline(headline, outputPath) {
     return renderImageFromSvg(svg, outputPath);
   } else if(headline.tags && headline.tags.htmlImg && headline.tags.htmlImg.htmlImgString) {
     const html = headline.tags.htmlImg.htmlImgString;
-    console.log(`\nRendering HTML:\n\n ${html}`);
+    if (config.logPrefs.html) {
+      console.log(`\nRendering HTML:\n\n ${html}`);
+    }
     const cropOptions = {
       width: 		parseInt(headline.tags.htmlImg.width),
       height: 	parseInt(headline.tags.htmlImg.height),


### PR DESCRIPTION
Adding a number of Card of the Day headlines that leverage `mtgcardfinder` to retrieve card data using tracery modifiers.

![card_of_the_day_relief_captain-56d6fd0d-ae02](https://user-images.githubusercontent.com/19597672/29749904-fe73d8ba-8aea-11e7-9b0f-93a2be43b7ab.png)

![card_of_the_day_banishing_knack-f847a85e-54ad](https://user-images.githubusercontent.com/19597672/29749936-6b57994e-8aeb-11e7-80f6-d90d372ff04f.png)